### PR TITLE
bugfix/session-create: wrong strategy hash key

### DIFF
--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -6,7 +6,7 @@ module API
 
         def create
           strategy = {
-            local: Auth::Local.new
+            email: Auth::Local.new
           }[user_params[:provider]&.to_sym]
 
           unless strategy


### PR DESCRIPTION
Issue: User login not working due to wrong key in strategy